### PR TITLE
Add Erlang support

### DIFF
--- a/config.xml.template
+++ b/config.xml.template
@@ -24,6 +24,7 @@
 <define name="#python" value="C:\Lang\Python\3.3.3\python.exe" />
 <define name="#haskell" value="C:\Lang\Haskell\2011.2.0.1\bin\ghc.exe" />
 <define name="#php" value="C:\Lang\PHP\5.4.0\php.exe" />
+<define name="#erlang" value="C:\Lang\Erlang\erl5.10.4\bin\erl.exe" />
 
 <define name="#qbasic" value="C:\Lang\QBasic\1.0\QBASIC.EXE" />
 <define name="#freeBasic" value="C:\Lang\FreeBasic\0.23\fbc.exe" />
@@ -267,4 +268,12 @@
     generate='#spawner%redir %limits #php %full_name %args'
     check='#spawner %limits "#php" %full_name %checker_args'/>
 
+<!-- Erlang -->
+<de
+    code="506"
+    compile='#spawner %comspec% /C ..\erlc.cmd "%full_name"'
+    run='#run "#erlang" -run "%name" -run init stop'
+    runfile='%name.beam'
+    generate='#spawner%redir %limits "#erlang" -run "%name" %args -run init stop'
+    check='#spawner %limits "#erlang" -run "%name" %checker_args -run init stop'/>
 </judge>

--- a/erlc.cmd
+++ b/erlc.cmd
@@ -1,0 +1,1 @@
+@C:\Lang\Erlang\erl5.10.4\bin\erlc.exe %* 2>&1


### PR DESCRIPTION
Erlang support for CATS.
To install Erlang:
1. Check out binaries form http://www.erlang.org/download.html;
2. Set up binaries into directory, which is referred in config file.

Important: "-run init stop" parameter is needed to stop Erlang VM after
execution.
