### PR TITLE
Abstract from interactor name

### DIFF
--- a/config.xml.template
+++ b/config.xml.template
@@ -14,7 +14,8 @@
 <define name='#spawner' value='..\spawner\sp'/>
 <define name="#arch_7z" value="C:\Program Files\7-Zip\7z.exe" />
 <define name="#run" value='#spawner -runas:1 -u:test -p:esta -ho:1 -so: -tl:%time_limit -ml:%memory_limit -wl:30 -sw:0 -y:1 %deadline'/>
-<define name="#run_interactive" value="#spawner --separator=// -hr=1 --out=nul -wl=30 -tl=%time_limit -ml=%memory_limit -y=1 --// -sr=report.txt --in=*1.stdout --out=*1.stdin server.exe --// %deadline -sr= "/>
+<define name="#default_interactor_name" value="Interact.exe" />
+<define name="#run_interactive" value="#spawner --separator=// -hr=1 --out=nul -wl=30 -tl=%time_limit -ml=%memory_limit -y=1 --// -sr=report.txt --in=*1.stdout --out=*1.stdin %interactor_name --// %deadline -sr= "/>
 <define name='#checker_args' value='"%test_answer" "%test_output" "%test_input"'/>
 <define name="#move" value="#spawner C:\WINDOWS\system32\cmd.exe /c move /y"/>
 
@@ -228,6 +229,8 @@
     code="401"
     compile='#spawner %comspec% /C ..\javac.cmd "%full_name"'
     run='#run "#java\java.exe" -Xss64m "%name"'
+    interactor_name='"#java\java.exe" -Xss64m "Interact"'
+    run_interactive='#run_interactive "#java\java.exe" -Xss64m "%name"'
     runfile='%name.class'
     generate='#spawner%redir %limits -wl:100 "#java\java.exe" -Xmx256m -Xss64m "%name" %args'
     check='#spawner %limits "#java\java.exe" -Xss64m "%name" %checker_args'/>

--- a/judge.pl
+++ b/judge.pl
@@ -41,6 +41,15 @@ sub get_cmd {
     $judge_de_idx{$de_id}->{$action};
 }
 
+sub get_cfg_define {
+    my $name = shift;
+    my $value = $cfg->defines->{$name};
+    if (!$value) {
+        log_msg("unknown define name: $name\n");
+    }
+    $value;
+}
+
 sub get_std_checker_cmd
 {
     my $std_checker_name = shift;
@@ -375,7 +384,7 @@ sub prepare_tests
 
             my $run_key = get_run_key($run_method);
             my $run_cmd = get_cmd($run_key, $ps->{de_id})
-                or return log_msg("No '$run_key' action for DE: $ps->{code}\n");;
+                or return log_msg("No '$run_key' action for DE: $ps->{code}\n");
 
             my ($vol, $dir, $fname, $name, $ext) = split_fname($ps->{fname});
 
@@ -879,7 +888,7 @@ sub process_request
 sub main_loop
 {
     log_msg("judge: %s\n", $judge->name);
-    log_msg("suppoted DEs: %s\n", join ',', sort { $a <=> $b } keys %{$cfg->DEs});
+    log_msg("supported DEs: %s\n", join ',', sort { $a <=> $b } keys %{$cfg->DEs});
 
     my_chdir($cfg->workdir) or return;
     for (my $i = 0; ; $i++) {

--- a/judge.pl
+++ b/judge.pl
@@ -323,6 +323,11 @@ sub input_output_redir {
     input_redir => input_or($_[0], ''), output_redir => output_or($_[1], ''),
 }
 
+sub interactor_name_or_default {
+    interactor_name => get_cmd("interactor_name", $_[0]) ||
+        get_cfg_define("#default_interactor_name"),
+}
+
 
 sub prepare_tests
 {
@@ -394,6 +399,7 @@ sub prepare_tests
                 time_limit => $ps->{time_limit} || $tlimit,
                 memory_limit => $ps->{memory_limit} || $mlimit,
                 deadline => ($ps->{time_limit} ? "-d:$ps->{time_limit}" : ''),
+                interactor_name_or_default($ps->{de_id}),
                 input_output_redir($input_fname, $output_fname),
             }) or return undef;
 
@@ -612,6 +618,7 @@ sub run_single_test
     my $exec_params = {
         filter_hash($problem, qw/name full_name time_limit memory_limit output_file/),
         input_output_redir(@$problem{qw(input_file output_file)}),
+        interactor_name_or_default($p{de_id}),
         test_rank => sprintf('%02d', $p{rank}),
     };
     $exec_params->{memory_limit} += $p{memory_handicap} || 0;

--- a/lib/CATS/Judge/Config.pm
+++ b/lib/CATS/Judge/Config.pm
@@ -8,7 +8,7 @@ use XML::Parser::Expat;
 sub required_fields() { qw(name rundir workdir report_file stdout_file formal_input_fname) }
 sub optional_fields() { qw(show_child_stdout save_child_stdout) }
 sub special_fields() { qw(defines DEs checkers) }
-sub de_fields() { qw(compile run run_interactive generate check runfile) }
+sub de_fields() { qw(compile run interactor_name run_interactive generate check runfile) }
 
 sub import {
     for (required_fields, optional_fields, special_fields) {

--- a/lib/CATS/Judge/Config.pm
+++ b/lib/CATS/Judge/Config.pm
@@ -7,7 +7,7 @@ use XML::Parser::Expat;
 
 sub required_fields() { qw(name rundir workdir report_file stdout_file formal_input_fname) }
 sub optional_fields() { qw(show_child_stdout save_child_stdout) }
-sub special_fields() { qw(DEs checkers) }
+sub special_fields() { qw(defines DEs checkers) }
 sub de_fields() { qw(compile run run_interactive generate check runfile) }
 
 sub import {
@@ -20,7 +20,7 @@ sub import {
 
 sub new {
     my ($class) = shift;
-    my $self = { DEs => {}, checkers => {} };
+    my $self = { defines => {}, DEs => {}, checkers => {} };
     bless $self, $class;
     $self;
 }
@@ -57,6 +57,8 @@ sub read_file {
         $h->();
     });
     $parser->parse($file);
+
+    $self->{defines} = $defines;
 
     $self->{$_} or die "config: undefined $_" for required_fields;
 }


### PR DESCRIPTION
Move interactor name string (`Server.exe`) out of `#run_interactive` define into `%interactor_name` for later interpolation within judge.pl. Default interactive name now specified by `#default_interactor_name` which is changed from `Server.exe` to `Interact.exe` according to most of NEERC interactive problems. To override default value for de specify `interactor_name` within this de's section in config.xml. 
e.g. for java `interactor_name='"#java\java.exe" -Xss64m "Interact"'`